### PR TITLE
Removed Kanban from the view modes for the Packages list in the UI

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -20,6 +20,7 @@
         'data/product.template.csv',
 	    'data/product.attribute.csv',
 	    'data/product.attribute.value.csv',
+	    'views/packages.xml',
         'views/edit_package.xml',
         'views/labeling.xml',
         'data/res.partner.csv',

--- a/views/packages.xml
+++ b/views/packages.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <data>
+    <record model="ir.actions.act_window" id="stock.action_package_view">
+        <field name="view_mode">tree,form</field>
+    </record>
+  </data>
+</odoo>


### PR DESCRIPTION
Closes #10. We don't believe that Kanban view makes sense for packages, so we're removing it.

@HaGuesto I wasn't sure that 'views' was necessarily the right place to put it, but it made more sense than the other locations we have right now.