### PR TITLE
Add Google Analytics tracking into Odoo

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -23,6 +23,7 @@
         'data/res.partner.csv',
         'data/website_menu.xml',
         'data/website_page.xml',
+        'data/website_settings.xml',
         # 'data/website_redirect.xml',
         'data/user_groups.xml',
         'views/packages.xml',

--- a/data/website_settings.xml
+++ b/data/website_settings.xml
@@ -1,0 +1,14 @@
+<odoo>
+    <data>
+        <record model="res.config.settings" id="res_config_settings_boxwise">
+            <field name="group_sale_delivery_address" eval="1"/>
+            <field name="has_google_analytics" eval="1"/>
+            <field name="google_analytics_key" eval="'UA-135092361-2'"/>
+        </record>
+
+        <function model="res.config.settings" name="execute">
+            <!-- ids = -->        <value eval="[ref('res_config_settings_boxwise')]"/>
+            <!-- context = -->    <value eval="{}"/>
+        </function>
+    </data>
+</odoo>

--- a/templates/assets.xml
+++ b/templates/assets.xml
@@ -7,9 +7,19 @@
     <template id="assets_frontend" inherit_id="web.assets_frontend">
         <xpath expr="." position="inside">
             <link rel="stylesheet" href="/boxwise_wms/static/src/css/boxwise.css" />
+            <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-135092361-2"></script>
+            <script>
+                window.dataLayer = window.dataLayer || [];
+                function gtag() {
+                    dataLayer.push(arguments);
+                }
+                gtag('js', new Date());
+                gtag('config', 'UA-135092361-2', {
+                    'anonymize_ip': true
+                });
+            </script>
         </xpath>
     </template>
-
 
     <template id="box_form_assets" name="Assets for the Box Form" inherit_id="web.assets_frontend" primary="True">
         <xpath expr="." position="inside">


### PR DESCRIPTION
* Fills in the website setting. Not needed right now as we're using custom templates, but I'm adding just in case we start using theirs anywhere
* Add to our own templates.