### PR TITLE
Introduce endpoints to generate QR codes directly from Boxwise

### DIFF
--- a/controllers/main.py
+++ b/controllers/main.py
@@ -40,3 +40,33 @@ class LabelingController(http.Controller):
     def qrcode(self, tenant, package):
         return werkzeug.utils.redirect('/boxwise/labeling/%s' % slug(package))
 
+    @http.route('/box/generate/', auth='user', methods=['POST'])
+    def generate(self, count):
+
+        package_model = http.request.env['stock.quant.package']
+        docids = []
+        for _ in range(int(count)):
+            docids.append(package_model.create({}).id)
+
+        return self._generate_qrcodes_report(docids)
+
+    @http.route('/box/reprint/', auth='user', methods=['POST'])
+    def reprint(self):
+
+        packages = http.request.env['stock.quant.package'].search([])
+        docids = []
+        for pack in packages:
+            if not any(pack.move_line_ids):
+                docids.append(pack.id)
+
+        return self._generate_qrcodes_report(docids)
+
+    def _generate_qrcodes_report(self, docids):
+        report = http.request.env['ir.actions.report']._get_report_from_name('boxwise_wms.report_qr_codes')
+        context = dict(http.request.env.context)
+
+        pdf = report.with_context(context).render_qweb_pdf(docids)[0]
+
+        pdfhttpheaders = [('Content-Type', 'application/pdf'), ('Content-Length', len(pdf))]
+        return http.request.make_response(pdf, headers=pdfhttpheaders)
+

--- a/views/find_package.xml
+++ b/views/find_package.xml
@@ -14,12 +14,17 @@
                 </section>
                 <section class="s_list">
                     <t t-if="empty_packages">
-                        <h4>
-                            Labels ready to use (empty boxes)
-                        </h4>
-                        <p>
-                            ToDo: Remove when the scanning works!
-                        </p>
+                        <form method="POST" action="/box/reprint/">
+
+                        <input type="hidden" name="csrf_token" t-att-value="request.csrf_token(None)"/>
+                            <input type="submit" value="Re-print labels" />
+                        </form>
+                        <form method="POST" action="/box/generate/">
+                        <input type="hidden" name="csrf_token" t-att-value="request.csrf_token(None)"/>
+                            <label for="count">count</label><input type="textbox" name="count" value="20"/>
+                            <input type="submit" value="Generate labels" />
+                        </form>
+                        <!--
                         <div class="list-group">
                             <t t-foreach="empty_packages" t-as="package">
                                 <a class="list-group-item list-group-item-action" t-attf-href="/box/edit/{{ slug(package) }}">
@@ -27,6 +32,7 @@
                                 </a>
                             </t>
                         </div>
+                         -->
                     </t>
                     <h4>
                         All Boxes


### PR DESCRIPTION
One generates new packages and triggers the report, the other re-generates all boxes that haven't been filled yet, fixes #32